### PR TITLE
Fix faulty flag

### DIFF
--- a/gclv
+++ b/gclv
@@ -170,7 +170,7 @@ while test $# -gt 0; do
       version="${1/*=/}"
       shift
       ;;
-    --from-file*)
+    --from-config*)
       if [ "${1/=/}" = "$1" ]; then
         shift
       fi


### PR DESCRIPTION
The flag from the help text and documentation did not match the code.

Use `--from-config` instead of `--from-file`.

Fixes #2 